### PR TITLE
Specify a project name when converting a manifest file into xml files.

### DIFF
--- a/pascalgt/transformer.py
+++ b/pascalgt/transformer.py
@@ -144,8 +144,7 @@ class GT2Pascal:
             xml_data,
             encoding="utf-8",
             xml_declaration=True,
-            pretty_print=True
-            )
+            pretty_print=True)
         with open(str(path_save), "wb") as f:
             f.write(out_xml)
         return


### PR DESCRIPTION

## What
* Specify a project name when converting a manifest file into xml files.

## Why
* Sometimes a manifest file has multiple results for multiple annotation jobs.

### Links to issues if exist
* [the link to an issue]()

## Checks
* What you checked
  - [x] unit tests

## Others
